### PR TITLE
Support for {} [] cyrollicLettersAndMarks latinAccentChars characters

### DIFF
--- a/js/src/extractUrlsWithIndices.js
+++ b/js/src/extractUrlsWithIndices.js
@@ -22,7 +22,6 @@ const extractUrlsWithIndices = function (text, options = DEFAULT_PROTOCOL_OPTION
     const protocol = RegExp.$4;
     const domain = RegExp.$5;
     const path = RegExp.$7;
-    const query = RegExp.$8;
     let endPosition = extractUrl.lastIndex;
     const startPosition = endPosition - url.length;
 

--- a/js/src/extractUrlsWithIndices.js
+++ b/js/src/extractUrlsWithIndices.js
@@ -22,6 +22,7 @@ const extractUrlsWithIndices = function (text, options = DEFAULT_PROTOCOL_OPTION
     const protocol = RegExp.$4;
     const domain = RegExp.$5;
     const path = RegExp.$7;
+    const query = RegExp.$8;
     let endPosition = extractUrl.lastIndex;
     const startPosition = endPosition - url.length;
 

--- a/js/src/regexp/validUrlQueryChars.js
+++ b/js/src/regexp/validUrlQueryChars.js
@@ -1,2 +1,8 @@
-const validUrlQueryChars = /[a-z0-9!?\*'@\(\);:&=\+\$\/%#\[\]\-_\.,~|\{\}]/i;
+import cyrillicLettersAndMarks from './cyrillicLettersAndMarks';
+import latinAccentChars from './latinAccentChars';
+import regexSupplant from '../lib/regexSupplant';
+
+const validUrlQueryChars = regexSupplant(/[a-z0-9!?\*'"@\(\);:&=\+\$\/%#\[\]\-_\.,~|\{\}#{cyrillicLettersAndMarks}#{latinAccentChars}]/i,
+    { cyrillicLettersAndMarks, latinAccentChars }
+);
 export default validUrlQueryChars;

--- a/js/src/regexp/validUrlQueryEndingChars.js
+++ b/js/src/regexp/validUrlQueryEndingChars.js
@@ -1,2 +1,2 @@
-const validUrlQueryEndingChars = /[a-z0-9\-_&=#\/]/i;
+const validUrlQueryEndingChars = /[a-z0-9\-_&=#\/\[\]\{\}]/i;
 export default validUrlQueryEndingChars;


### PR DESCRIPTION
Twitter-text is used in Falcon for URL detection. However, it has some limitations compared with what Facebook natively is supporting. This PR is addressing those limitations by adding the following changes:
- Support for characters `[]` and `{}` on URL query
- Support for characters `cyrollicLettersAndMark` and `latinAccentChars`

The specification for URL query says clearly that the previous characters should not be supported on URL query (https://tools.ietf.org/html/rfc3986#section-3.4). However, I haven't found a cleaner way of having the same behaviour as Facebook natively does.

One issue by adding these changes is the false positive we can provide to Twitter users since we will extract a link which will not be fully supported by Twitter. 